### PR TITLE
feat: add language coaching corrections

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -58,6 +58,7 @@
     <section class="subtitles">
       <div id="botEnLine" class="line">[EN] —</div>
       <div id="botEsLine" class="line">[ES] —</div>
+      <div id="botCorrectionLine" class="line">[Feedback] —</div>
     </section>
 
     <section style="margin-top:16px;">


### PR DESCRIPTION
## Summary
- teach the assistant to act as a language coach, asking for native and target languages
- return grammar and pronunciation feedback in the user's native language via a new `corrections` field
- surface coaching feedback and conversation history on the client side

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68afb266d2508327a98ff4eb84c95530